### PR TITLE
[월말 비교 알람 에러 수정]

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.jp_ais_training.keibo">
 
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application
         android:name="com.jp_ais_training.main.sharedPreferences.MyApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/jp_ais_training/keibo/main/Const.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/main/Const.kt
@@ -21,6 +21,11 @@ object Const {
     val KINYU_NOTI_KEY = "KinyuNoti"
     val COMPARISON_EXPENSE_NOTI_KEY = "ComparisonExpense"
 
+    val FIX_EXPENSE_NOTI_CONTENT_TITLE = "定期固定支出通知"
+    val FIX_EXPENSE_NOTI_CONTENT_TEXT_1 = "明日"
+    val FIX_EXPENSE_NOTI_CONTENT_TEXT_2 = "支出予定です。"
+
+
     val KINYU_NOTI_CONTENT_TITLE = "家計簿記入要請通知"
     val KINYU_NOTI_CONTENT_TEXT = "家計簿記入が届いてありません。記入してください!"
 

--- a/app/src/main/java/com/jp_ais_training/keibo/main/NotificationUtil.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/main/NotificationUtil.kt
@@ -8,15 +8,25 @@ import android.graphics.Color
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
+import com.jp_ais_training.keibo.main.model.AppDatabase
+import com.jp_ais_training.keibo.main.model.Response.ExpenseItemType
 import com.jp_ais_training.keibo.main.notireceiver.ComparisonExpenseNotiReceiver
+import com.jp_ais_training.keibo.main.notireceiver.FixExpenseReceiver
 import com.jp_ais_training.keibo.main.notireceiver.KinyuNotiReceiver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.text.SimpleDateFormat
 import java.util.*
 
 @RequiresApi(Build.VERSION_CODES.O)
-class NotificationUtil(context: Context): ContextWrapper(context) {
+class NotificationUtil(context: Context) : ContextWrapper(context) {
 
     private val TAG = this::class.java.simpleName.toString()
     lateinit var manager: NotificationManager
+
+    private val mContext = this
 
     fun createChannels() {
         manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -32,9 +42,9 @@ class NotificationUtil(context: Context): ContextWrapper(context) {
         // 이 채널에 게시된 알림이 진동해야 하는지 여부를 설정합니다.
         fixExpenseChannel.enableVibration(true)
         // 이 채널에 게시된 알림에 대한 알림 라이트 색을 설정합니다.
-        fixExpenseChannel.lightColor= Color.GREEN
+        fixExpenseChannel.lightColor = Color.GREEN
 // 이 채널에 게시된 알림이 잠금 화면에 표시되는지 여부를 설정합니다.
-        fixExpenseChannel.lockscreenVisibility= Notification.VISIBILITY_PUBLIC
+        fixExpenseChannel.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         manager.createNotificationChannel(fixExpenseChannel)
 
         // 가계부 기입 요청 알림 채널 생성
@@ -48,9 +58,9 @@ class NotificationUtil(context: Context): ContextWrapper(context) {
         // 이 채널에 게시된 알림이 진동해야 하는지 여부를 설정합니다.
         kinyuChannel.enableVibration(true)
         // 이 채널에 게시된 알림에 대한 알림 라이트 색을 설정합니다.
-        kinyuChannel.lightColor= Color.GREEN
+        kinyuChannel.lightColor = Color.GREEN
 // 이 채널에 게시된 알림이 잠금 화면에 표시되는지 여부를 설정합니다.
-        kinyuChannel.lockscreenVisibility= Notification.VISIBILITY_PUBLIC
+        kinyuChannel.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         manager.createNotificationChannel(kinyuChannel)
 
         // 월말 지출 비교 알림
@@ -64,15 +74,124 @@ class NotificationUtil(context: Context): ContextWrapper(context) {
         // 이 채널에 게시된 알림이 진동해야 하는지 여부를 설정합니다.
         kinyuChannel.enableVibration(true)
         // 이 채널에 게시된 알림에 대한 알림 라이트 색을 설정합니다.
-        kinyuChannel.lightColor= Color.GREEN
+        kinyuChannel.lightColor = Color.GREEN
 // 이 채널에 게시된 알림이 잠금 화면에 표시되는지 여부를 설정합니다.
-        kinyuChannel.lockscreenVisibility= Notification.VISIBILITY_PUBLIC
+        kinyuChannel.lockscreenVisibility = Notification.VISIBILITY_PUBLIC
         manager.createNotificationChannel(comparisonChannel)
-
     }
 
     // 정기 고정 지출 알림 설정
+    // 1. 이번달 DB 데이터 확인 (고정 지출)
+    // 2. 오늘 이전날은 제외하고, 오늘부터 이번달내에 있는 고정 지출 알람 (하루전 21시)
+    // 3. 한달에 한번씩 반복되도록 함
     fun setFixExpenseNotification() {
+        // 알람 매니저 생성
+        val alarmManager = getSystemService(ALARM_SERVICE) as AlarmManager
+
+        val DB = AppDatabase.getInstance(this)!!
+
+
+            CoroutineScope(Dispatchers.IO).launch {
+                val list = DB.dao().loadEI("2022-05")
+
+                for (item in list) {
+                    val sdf = SimpleDateFormat("yyyy-MM-dd")
+                    val date = sdf.parse(item.datetime)
+                    val itemCalendar = Calendar.getInstance()
+                    // item.datetime을 담고 있는 calendar 객체
+                    itemCalendar.time = date
+
+                    // 정확하게는 하루 전 날짜 데이터를 담아야한다.
+                    // 더 정확하게는 하루 전 21시 날짜 데이터를 담아야 한다.
+                    // 알림이 발생하는 건 고정 지출 하루전 21시이기 때문이다.
+                    // 비교가 필요한 이유는 이미 과거에 데이터이면, 알림을 발생시킬 필요가 없고
+                    // 과거 시간에 알람을 발생시키면 무시하는게 아니라, 코드가 동작하는 순간에 알람을 주는 에러가 발생한다.
+                    itemCalendar.set(
+                        Calendar.DAY_OF_MONTH,
+                        itemCalendar.get(Calendar.DAY_OF_MONTH) - 1
+                    )   // 고정지출 하루 전
+                    itemCalendar.set(
+                        Calendar.HOUR_OF_DAY,
+                        Const.NOTI_HOUR_OF_DAY_21
+                    )                       // 21시
+                    itemCalendar.set(
+                        Calendar.MINUTE,
+                        Const.NOTI_MINUTE_ZERO
+                    )                               // 00분
+                    itemCalendar.set(
+                        Calendar.SECOND,
+                        Const.NOTI_SECOND_ZERO
+                    )                               // 00초
+                    itemCalendar.set(
+                        Calendar.MILLISECOND,
+                        Const.NOTI_MILLISECOND_ZERO
+                    )                     // 00초
+
+                    // 오늘 날짜 데이터를 담는 캘린더 객체
+                    val currentCalendar = Calendar.getInstance()
+                    val alarmCalendar = Calendar.getInstance()
+
+                    // 테스트 하려면 조건문 주석
+                    if (currentCalendar.timeInMillis >= itemCalendar.timeInMillis) {    // 현재 시각 >= 알림 발생 시각 -> 과거와 현재를 의미
+                        // 다음달 알람을 설정 + 한달마다 반복
+                        alarmCalendar.set(
+                            Calendar.MONTH,
+                            currentCalendar.get(Calendar.MONTH) + 1
+                        ) // 다음달
+                        alarmCalendar.set(
+                            Calendar.DAY_OF_MONTH,
+                            itemCalendar.get(Calendar.DAY_OF_MONTH)
+                        )   // 고정지출 하루전(-1은 위에서 이미 실시함)
+                        alarmCalendar.set(Calendar.HOUR_OF_DAY, Const.NOTI_HOUR_OF_DAY_21)  // 21시
+                        alarmCalendar.set(Calendar.MINUTE, Const.NOTI_MINUTE_ZERO)  // 00분
+                        alarmCalendar.set(Calendar.SECOND, Const.NOTI_SECOND_ZERO)  // 00초
+                        alarmCalendar.set(Calendar.MILLISECOND, Const.NOTI_MILLISECOND_ZERO)  // 00초
+
+                    } else { // 현재 시각 < 아이템 시각 -> 미래를 의미
+                        // 이번달 알람을 설정 + 한달마다 반복
+                        val alarmCalendar = Calendar.getInstance()
+                        alarmCalendar.set(
+                            Calendar.MONTH,
+                            currentCalendar.get(Calendar.MONTH)
+                        ) // 이번달
+                        alarmCalendar.set(
+                            Calendar.DAY_OF_MONTH,
+                            itemCalendar.get(Calendar.DAY_OF_MONTH)
+                        )   // 고정지출 하루전(-1은 위에서 이미 실시함)
+                        alarmCalendar.set(Calendar.HOUR_OF_DAY, Const.NOTI_HOUR_OF_DAY_21)  // 21시
+                        alarmCalendar.set(Calendar.MINUTE, Const.NOTI_MINUTE_ZERO)  // 00분
+                        alarmCalendar.set(Calendar.SECOND, Const.NOTI_SECOND_ZERO)  // 00초
+                        alarmCalendar.set(Calendar.MILLISECOND, Const.NOTI_MILLISECOND_ZERO)  // 00초
+                    }
+
+                    val year = alarmCalendar.get(Calendar.YEAR)
+                    val month = alarmCalendar.get(Calendar.MONTH) + 1
+                    val day = alarmCalendar.get(Calendar.DAY_OF_MONTH)
+                    val hour = alarmCalendar.get(Calendar.HOUR_OF_DAY)
+                    val minute = alarmCalendar.get(Calendar.MINUTE)
+                    val second = alarmCalendar.get(Calendar.SECOND)
+
+
+                    val intent = Intent(mContext, FixExpenseReceiver::class.java)
+                    // 고정 지출 이전일 21시00분00초에 실행되는 intent
+                    val pendingIntent = PendingIntent.getBroadcast(
+                        mContext,
+                        Const.NOTI_RECEIVER_PENDING_INTENT_REQUEST_CODE,
+                        intent,
+                        Const.NOTI_RECEIVER_PENDING_INTENT_FLAGS
+                    )
+                    alarmManager.setExact(
+                        AlarmManager.RTC_WAKEUP,
+                        alarmCalendar.timeInMillis,
+                        pendingIntent
+                    )
+
+                    Log.e(
+                        TAG,
+                        "item.datetime: ${item.datetime}, itemDatetime: $year-$month-$day $hour:$minute:$second"
+                    )
+                }
+        }
 
     }
 
@@ -99,12 +218,18 @@ class NotificationUtil(context: Context): ContextWrapper(context) {
             intent,
             Const.NOTI_RECEIVER_PENDING_INTENT_FLAGS
         )
-        alarmManager.setInexactRepeating(
+        alarmManager.setExact(
             AlarmManager.RTC_WAKEUP,
             calendar.timeInMillis,
-            AlarmManager.INTERVAL_DAY,
             pendingIntent
         )
+        // setInexactRepeating 성능 이슈로 setExact로 변경
+//        alarmManager.setInexactRepeating(
+//            AlarmManager.RTC_WAKEUP,
+//            calendar.timeInMillis,
+//            AlarmManager.INTERVAL_DAY,
+//            pendingIntent
+//        )
     }
 
     // 월말 지출 비교 알림 설정
@@ -122,7 +247,7 @@ class NotificationUtil(context: Context): ContextWrapper(context) {
         val currentHour = calendar.get(Calendar.HOUR_OF_DAY)
 
         // 오늘이 25일이 넘으면, 다음달 25일로 넘김
-        if(currentDay > Const.NOTI_DAY_OF_MONTH_25) {
+        if (currentDay > Const.NOTI_DAY_OF_MONTH_25) {
             // 매월 25일 21시00분00초
             calendar.set(Calendar.MONTH, currentMonth + 1)  // 다음달
             calendar.set(Calendar.DAY_OF_MONTH, Const.NOTI_DAY_OF_MONTH_25) // 25일
@@ -135,8 +260,7 @@ class NotificationUtil(context: Context): ContextWrapper(context) {
         else if (currentDay == Const.NOTI_DAY_OF_MONTH_25 && currentHour == Const.NOTI_HOUR_OF_DAY_21) {
             // 21시이후 ~24시까지는 알람을 수행하지 않음
             return
-        }
-        else {  // 오늘이 25일을 넘지않으면, 이번달 25일 21시로 설정
+        } else {  // 오늘이 25일을 넘지않으면, 이번달 25일 21시로 설정
             // 매월 25일 21시00분00초
             calendar.set(Calendar.DAY_OF_MONTH, Const.NOTI_DAY_OF_MONTH_25) // 25일
             calendar.set(Calendar.HOUR_OF_DAY, Const.NOTI_HOUR_OF_DAY_21)  // 21시
@@ -154,14 +278,20 @@ class NotificationUtil(context: Context): ContextWrapper(context) {
         )
 
         // calendar.getActualMaximum(Calendar.DAY_OF_MONTH)는 매달 달라져야함, 정확히 25일이 아닐 수 있음. 추후 수정 필요
-        alarmManager.setInexactRepeating(
+        alarmManager.setExact(
             AlarmManager.RTC_WAKEUP,
             calendar.timeInMillis,
-            AlarmManager.INTERVAL_DAY* calendar.getActualMaximum(
-                Calendar.DAY_OF_MONTH
-            ),
             pendingIntent
         )
+        // setInexactRepeating 성능 이슈로 setExact로 변경
+//        alarmManager.setInexactRepeating(
+//            AlarmManager.RTC_WAKEUP,
+//            calendar.timeInMillis,
+//            AlarmManager.INTERVAL_DAY* calendar.getActualMaximum(
+//                Calendar.DAY_OF_MONTH
+//            ),
+//            pendingIntent
+//        )
 
     }
 

--- a/app/src/main/java/com/jp_ais_training/keibo/main/notireceiver/FixExpenseReceiver.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/main/notireceiver/FixExpenseReceiver.kt
@@ -1,0 +1,93 @@
+package com.jp_ais_training.keibo.main.notireceiver
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.jp_ais_training.keibo.R
+import com.jp_ais_training.keibo.main.Const
+import com.jp_ais_training.keibo.main.MainActivity
+import com.jp_ais_training.keibo.main.model.AppDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.*
+
+class FixExpenseReceiver : BroadcastReceiver() {
+
+    private val TAG = this::class.java.simpleName.toString()
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+
+        // 해당 리시버가 동작했다는 것은 내일(리시버가 동작한 다음날) 고정 지출이 있고,
+        // 이에 대해 알림이 필요하다는 것을 의미
+        val calendar = Calendar.getInstance()
+        Log.d(TAG, "FixExpenseReceiver ${calendar.timeInMillis}")
+
+        // 날짜 데이터를 내일,하루뒤로 변경
+        calendar.set(Calendar.DAY_OF_MONTH, calendar.get(Calendar.DAY_OF_MONTH) + 1)
+
+        val year = calendar.get(Calendar.YEAR)
+        val month = (calendar.get(Calendar.MONTH) + 1).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+        val day = calendar.get(Calendar.DAY_OF_MONTH).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+
+        val tomorrow = "$year-$month-$day"
+//        val tomorrow = "2022-05-11"   // for test
+
+        val DB = AppDatabase.getInstance(context!!)!!
+
+        CoroutineScope(Dispatchers.IO).launch {
+            // $year-$month-$day : YYYY-MM-DD
+            val fixExpenseList = DB.dao().loadFixEI(tomorrow)
+
+            Log.d(TAG, "fixExpenseList: $fixExpenseList")
+
+            fixExpenseList.forEachIndexed { index, item ->
+                val intent = Intent(context, MainActivity::class.java)
+                intent.flags = (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+
+                val pendingIntent = PendingIntent.getActivity(
+                    context,
+                    Const.PENDING_INTENT_REQUEST_CODE,
+                    intent,
+                    Const.PENDING_INTENT_FLAGS
+                )
+
+                val contentTitle = Const.FIX_EXPENSE_NOTI_CONTENT_TITLE
+                // 明日(XXXX-XX-XX)
+                val contentText = "${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_1}" +
+                        "($tomorrow) ${item.name} ${item.price}円 ${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_2}"
+
+                val builder = NotificationCompat.Builder(context!!, Const.KINYU_CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_launcher_background)
+                    .setContentTitle(contentTitle)
+                    .setContentText(contentText)
+                    .setAutoCancel(true)
+                    .setDefaults(NotificationCompat.DEFAULT_ALL)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setContentIntent(pendingIntent)
+
+                val notificationManagerCompat = NotificationManagerCompat.from(context!!)
+                notificationManagerCompat.notify(0, builder.build())    // 한번에 묶어서
+//                notificationManagerCompat.notify(index, builder.build())  // 따로따로
+            }
+        }
+    }
+}


### PR DESCRIPTION
# What To Do
- AndroidManifest.xml : 알람관련 퍼미션 추가
- Const.kt : 정기고정지출 알림 관련 상수 추가
- NotificationUtil.kt : 정기 고정 지출 알림 추가
- FixExpenseReceiver.kt : 정기 고정 지출 알림 관련 리시버 추가

# 설명
- 알람 관련 퍼미션은
- "Setting Exact alarms with setExact requires the SCHEDULE_EXACT_ALARM permission or power exemption from user; it is intended for applications where the user knowingly schedules actions to happen at a precise time such as alarms, clocks, calendars, etc. Check out the javadoc on this permission to make sure your use case is valid."
- setExact를 사용하여 정확한 알람을 설정하려면 SCHECLE_EXACT_ALARM 사용 권한 또는 사용자 전원 면제가 필요합니다. 사용자가 알람, 시계, 캘린더 등과 같은 정확한 시간에 수행되도록 작업을 계획하는 응용 프로그램을 대상으로 합니다. 사용 사례가 유효한지 확인하려면 이 권한의 javadoc를 확인하십시오.
- 정확한 알림을 지원하는 setExact를 사용하려면 alarm permission 필요

# 결과 이미지
![fixexpense_2](https://user-images.githubusercontent.com/56281493/170639517-29bcf9b2-189d-4d53-abfc-a12299579182.png)
