### PR TITLE
[알람 테스트 레이아웃, 로직 추가]

### DIFF
--- a/app/src/main/java/com/jp_ais_training/keibo/frament/SettingsFragment.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/frament/SettingsFragment.kt
@@ -1,19 +1,34 @@
 package com.jp_ais_training.keibo.frament
 
+import android.app.AlertDialog
+import android.app.Dialog
+import android.app.PendingIntent
 import android.content.Context.MODE_PRIVATE
+import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
 import com.jp_ais_training.keibo.R
+import com.jp_ais_training.keibo.activity.MainActivity
+import com.jp_ais_training.keibo.databinding.DialogTestBinding
 import com.jp_ais_training.keibo.databinding.FragmentSettingsBinding
+import com.jp_ais_training.keibo.db.AppDatabase
+import com.jp_ais_training.keibo.model.response.LoadSumEI
 import com.jp_ais_training.keibo.util.Const
 import com.jp_ais_training.keibo.util.NotificationUtil
+import kotlinx.coroutines.*
+import java.text.SimpleDateFormat
+import java.util.*
+
 
 class SettingsFragment : Fragment() {
 
@@ -30,6 +45,8 @@ class SettingsFragment : Fragment() {
 
         initSwitchValue()
         setClickEvent()
+
+        setTestEvent()
 
         return binding.root
     }
@@ -139,23 +156,287 @@ class SettingsFragment : Fragment() {
         }
     }
 
-    override fun onStart() {
-        super.onStart()
+
+    private fun setTestEvent() {
+        // 매월 1일 자동 추가
+        binding.btnAutoAdd.setOnClickListener {
+
+            val prevMonthAsYYYYMM = getPrevMonthAsYYYYMM()
+            val db = AppDatabase.getInstance(requireContext())!!
+
+
+                runBlocking {
+                    val currentList = ArrayList<String>()
+                    var prevList = ArrayList<String>()
+                    CoroutineScope(Dispatchers.IO).async {
+                        val prevMonthFixExpenseList = db.dao().loadEI(prevMonthAsYYYYMM).filter { item ->
+                            item.type == "fix"
+                        }
+                        prevMonthFixExpenseList.forEach {
+                            it.datetime?.let { it1 -> prevList.add(it1) }
+                        }
+
+                        // 이번달 Calendar 객체
+                        val currentCalendar = Calendar.getInstance()
+                        val currentMonthAsInt = currentCalendar.get(Calendar.MONTH) // 이번달
+                        val lastDayOfCurrentMonth = currentCalendar.getActualMaximum(Calendar.DAY_OF_MONTH) // 이번달의 마지막날
+
+                        for (item in prevMonthFixExpenseList) {
+                            // datetime(String)를 Calendar 객체로 변환
+                            val itemDatetime = item.datetime
+                            val cal = convertStringToCalendar(itemDatetime)
+                            // 이번달로 변경
+                            cal.set(Calendar.MONTH, currentMonthAsInt)
+
+                            val itemDay = cal.get(Calendar.DAY_OF_MONTH)
+                            if (itemDay > lastDayOfCurrentMonth) {
+                                // 아이템의 datetime의 날짜가 현재달의 마지막날보다 큰 경우
+                                // 1월 31일 데이터를 2월(28일까지밖에없음)에 추가해야하는 경우
+                                // "이번달의 마지막날로 추가하자!"
+                                cal.set(Calendar.DAY_OF_MONTH, lastDayOfCurrentMonth)
+                            } else {
+                                cal.set(Calendar.DAY_OF_MONTH, itemDay)
+                            }
+
+                            val newDatetime = convertCalendarToString(cal)
+                            currentList.add(newDatetime)
+                        }
+                    }.await()
+
+                    val dialogBinding: DialogTestBinding = DataBindingUtil
+                        .inflate(LayoutInflater.from(context), R.layout.dialog_test, null, false)
+                    val dialog = Dialog(requireContext())
+
+                    dialogBinding.prev.text = prevList.toString()
+                    dialogBinding.current.text = currentList.toString()
+
+                    dialog.setContentView(dialogBinding.root)
+                    dialog.show()
+                }
+
+
+        }
+        // 매일 기입요청 알람
+        binding.btnKinyuNoti.setOnClickListener {
+            setKinyuNoti()
+        }
+        // 이전달, 이번달 지출 비교 알람
+        binding.btnComparisonNoti.setOnClickListener {
+            setComparisonNoti()
+        }
+        // 다음날 고정 지출 알람
+        val tomorrow = "2022-05-11"   // for test
+        binding.btnFixExpenseNoti.text = "固定支出($tomorrow)"
+        binding.btnFixExpenseNoti.setOnClickListener {
+            setNotiFixExpense()
+        }
     }
 
-    override fun onResume() {
-        super.onResume()
+    private fun setKinyuNoti() {
+        val calendar = Calendar.getInstance()
+
+        val year = calendar.get(Calendar.YEAR)
+        val month = (calendar.get(Calendar.MONTH) + 1).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+        val day = calendar.get(Calendar.DAY_OF_MONTH).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+
+        val today = "$year-$month-$day"
+
+        val intent = Intent(context, MainActivity::class.java)
+        intent.flags = (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        intent.putExtra(Const.NOTI_INTENT_TYPE_KEY_WHAT_TO_DO, Const.NOTI_INTENT_TYPE_VALUE_GO_TO_SYOUSAI_PAGE)
+        intent.putExtra(Const.KINYU_MAIN_ACTIVITY_EXTRA_YEAR, year)
+        intent.putExtra(Const.KINYU_MAIN_ACTIVITY_EXTRA_MONTH, month)
+        intent.putExtra(Const.KINYU_MAIN_ACTIVITY_EXTRA_DAY, day)
+
+        val pendingIntent = PendingIntent.getActivity(context, Const.PENDING_INTENT_REQUEST_CODE, intent, Const.PENDING_INTENT_FLAGS)
+
+        val contentTitle = Const.KINYU_NOTI_CONTENT_TITLE
+        val contentText = "$today\n${Const.KINYU_NOTI_CONTENT_TEXT}"
+
+        val builder = NotificationCompat.Builder(requireContext()!!, Const.KINYU_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_background)
+            .setContentTitle(contentTitle)
+            .setContentText(contentText)
+            .setAutoCancel(true)
+            .setStyle(NotificationCompat.BigTextStyle())
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+
+        val notificationManagerCompat = NotificationManagerCompat.from(requireContext())
+        notificationManagerCompat.notify(Const.KINYU_NOTIFICATION_ID, builder.build())
+
+    }
+    private fun setComparisonNoti() {
+        val calendar = Calendar.getInstance()
+
+        val currentYear = calendar.get(Calendar.YEAR)
+        val currentMonth = (calendar.get(Calendar.MONTH) + 1).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+
+        calendar.set(Calendar.MONTH, calendar.get(Calendar.MONTH) - 1)
+
+        val prevYear = calendar.get(Calendar.YEAR)
+        val prevMonth = (calendar.get(Calendar.MONTH) + 1).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+
+        val current = "$currentYear-$currentMonth"
+        val prev = "$prevYear-$prevMonth"
+
+        val DB = AppDatabase.getInstance(requireContext())!!
+
+        CoroutineScope(Dispatchers.IO).launch {
+
+            val currentMonthExpenseSum: LoadSumEI =  DB.dao().loadMonthSumEI(current)[0]
+            val prevMonthExpenseSum: LoadSumEI =  DB.dao().loadMonthSumEI(prev)[0]
+            // 데이터가 있을 경우
+            if (currentMonthExpenseSum.price != null && prevMonthExpenseSum.price != null) {
+                val intent = Intent(context, MainActivity::class.java)
+                intent.putExtra(Const.NOTI_INTENT_TYPE_KEY_WHAT_TO_DO, Const.NOTI_INTENT_TYPE_VALUE_GO_TO_BAR_STATISTIC)
+                intent.flags = (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+
+                val pendingIntent = PendingIntent.getActivity(context, Const.PENDING_INTENT_REQUEST_CODE, intent, Const.PENDING_INTENT_FLAGS)
+
+                val contentTitle = Const.COMPARISON_NOTI_CONTENT_TITLE
+                val contentText =
+                    "${Const.COMPARISON_NOTI_CONTENT_TEXT_1}${prevMonthExpenseSum.price}円\n" +
+                            "${Const.COMPARISON_NOTI_CONTENT_TEXT_2}${currentMonthExpenseSum.price}円\n" +
+                            "${Const.COMPARISON_NOTI_CONTENT_TEXT_3}${currentMonthExpenseSum.price - prevMonthExpenseSum.price}${Const.COMPARISON_NOTI_CONTENT_TEXT_4}"
+
+                Log.d(TAG, "${currentMonthExpenseSum.price} - prevMonthExpenseSum.price: ${currentMonthExpenseSum.price - prevMonthExpenseSum.price}")
+
+                val builder = NotificationCompat.Builder(requireContext(), Const.COMPARISON_CHANNEL_ID)
+                    .setSmallIcon(R.drawable.ic_launcher_background)
+                    .setContentTitle(contentTitle)
+                    .setContentText(contentText)
+                    .setAutoCancel(true)
+                    .setStyle(NotificationCompat.BigTextStyle())
+                    .setDefaults(NotificationCompat.DEFAULT_ALL)
+                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setContentIntent(pendingIntent)
+
+                val notificationManagerCompat = NotificationManagerCompat.from(requireContext())
+                notificationManagerCompat.notify(Const.COMPARISON_NOTIFICATION_ID, builder.build())
+            }
+
+        }
+    }
+    private fun setNotiFixExpense() {
+// 해당 리시버가 동작했다는 것은 내일(리시버가 동작한 다음날) 고정 지출이 있고,
+        // 이에 대해 알림이 필요하다는 것을 의미
+        val tomorrow = "2022-05-11"   // for test
+
+        val DB = AppDatabase.getInstance(requireContext())!!
+
+        CoroutineScope(Dispatchers.IO).launch {
+            // $year-$month-$day : YYYY-MM-DD
+            val fixExpenseList = DB.dao().loadFixEI(tomorrow)
+
+            Log.d(TAG, "fixExpenseList: $fixExpenseList")
+
+            val intent = Intent(context, MainActivity::class.java)
+            intent.flags = (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                Const.PENDING_INTENT_REQUEST_CODE,
+                intent,
+                Const.PENDING_INTENT_FLAGS
+            )
+
+            val contentTitle = Const.FIX_EXPENSE_NOTI_CONTENT_TITLE
+            // 明日(XXXX-XX-XX)
+            var contentText = "${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_1} ($tomorrow)\n"
+            var sum = 0
+            for (item in fixExpenseList) {
+                contentText += "${item.name} ${item.price}円\n"
+                item.price?.let {
+                    sum+= it
+                }
+            }
+            contentText += "合計(${sum}円) ${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_2}"
+
+            val builder = NotificationCompat.Builder(requireContext(), Const.KINYU_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_launcher_background)
+                .setContentTitle(contentTitle)
+                .setContentText(contentText)
+                .setAutoCancel(true)
+                .setStyle(NotificationCompat.BigTextStyle())
+                .setDefaults(NotificationCompat.DEFAULT_ALL)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setContentIntent(pendingIntent)
+
+            val notificationManagerCompat = NotificationManagerCompat.from(requireContext())
+            notificationManagerCompat.notify(Const.FIX_EXPENSE_NOTIFICATION_ID, builder.build())    // 한번에 묶어서
+//                notificationManagerCompat.notify(index, builder.build())  // 따로따로
+        }
     }
 
-    override fun onPause() {
-        super.onPause()
+    private fun convertStringToCalendar(itemDatetime: String?): Calendar {
+        val sdf = SimpleDateFormat("yyyy-MM-dd")
+        val date: Date = sdf.parse(itemDatetime)
+        val cal = Calendar.getInstance()
+        cal.time = date
+
+        return cal
     }
 
-    override fun onStop() {
-        super.onStop()
+    private fun convertCalendarToString(cal: Calendar): String {
+        val year = cal.get(Calendar.YEAR)
+        val month = (cal.get(Calendar.MONTH) + 1).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+        val day = cal.get(Calendar.DAY_OF_MONTH).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+
+        return "$year-$month-$day"
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
+    private fun getPrevMonthAsYYYYMM(): String {
+        // 이전달 Calendar 객체
+        val prevCalendar = Calendar.getInstance()
+        prevCalendar.set(Calendar.MONTH, prevCalendar.get(Calendar.MONTH) - 1)
+
+        val prevYear = prevCalendar.get(Calendar.YEAR)
+        val prevMonth = (prevCalendar.get(Calendar.MONTH) + 1).let {
+            if (it < 10) {
+                "0$it"
+            } else {
+                it.toString()
+            }
+        }
+
+        return "$prevYear-$prevMonth"
     }
 }

--- a/app/src/main/java/com/jp_ais_training/keibo/receiver/ComparisonExpenseNotiReceiver.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/receiver/ComparisonExpenseNotiReceiver.kt
@@ -67,8 +67,8 @@ class ComparisonExpenseNotiReceiver: BroadcastReceiver() {
 
                     val contentTitle = Const.COMPARISON_NOTI_CONTENT_TITLE
                     val contentText =
-                        "${Const.COMPARISON_NOTI_CONTENT_TEXT_1}${currentMonthExpenseSum.price}円\n" +
-                                "${Const.COMPARISON_NOTI_CONTENT_TEXT_2}${prevMonthExpenseSum.price}円\n" +
+                        "${Const.COMPARISON_NOTI_CONTENT_TEXT_1}${prevMonthExpenseSum.price}円\n" +
+                                "${Const.COMPARISON_NOTI_CONTENT_TEXT_2}${currentMonthExpenseSum.price}円\n" +
                                 "${Const.COMPARISON_NOTI_CONTENT_TEXT_3}${currentMonthExpenseSum.price - prevMonthExpenseSum.price}${Const.COMPARISON_NOTI_CONTENT_TEXT_4}"
 
                     val builder = NotificationCompat.Builder(context!!, Const.COMPARISON_CHANNEL_ID)
@@ -76,12 +76,13 @@ class ComparisonExpenseNotiReceiver: BroadcastReceiver() {
                         .setContentTitle(contentTitle)
                         .setContentText(contentText)
                         .setAutoCancel(true)
+                        .setStyle(NotificationCompat.BigTextStyle())
                         .setDefaults(NotificationCompat.DEFAULT_ALL)
                         .setPriority(NotificationCompat.PRIORITY_HIGH)
                         .setContentIntent(pendingIntent)
 
                     val notificationManagerCompat = NotificationManagerCompat.from(context!!)
-                    notificationManagerCompat.notify(0, builder.build())
+                    notificationManagerCompat.notify(Const.COMPARISON_NOTIFICATION_ID, builder.build())
                 }
 
             }

--- a/app/src/main/java/com/jp_ais_training/keibo/receiver/FixExpenseReceiver.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/receiver/FixExpenseReceiver.kt
@@ -57,35 +57,40 @@ class FixExpenseReceiver : BroadcastReceiver() {
 
             Log.d(TAG, "fixExpenseList: $fixExpenseList")
 
-            fixExpenseList.forEachIndexed { index, item ->
-                val intent = Intent(context, MainActivity::class.java)
-                intent.flags = (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            val intent = Intent(context, MainActivity::class.java)
+            intent.flags = (Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
 
-                val pendingIntent = PendingIntent.getActivity(
-                    context,
-                    Const.PENDING_INTENT_REQUEST_CODE,
-                    intent,
-                    Const.PENDING_INTENT_FLAGS
-                )
+            val pendingIntent = PendingIntent.getActivity(
+                context,
+                Const.PENDING_INTENT_REQUEST_CODE,
+                intent,
+                Const.PENDING_INTENT_FLAGS
+            )
 
-                val contentTitle = Const.FIX_EXPENSE_NOTI_CONTENT_TITLE
-                // 明日(XXXX-XX-XX)
-                val contentText = "${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_1}" +
-                        "($tomorrow) ${item.name} ${item.price}円 ${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_2}"
-
-                val builder = NotificationCompat.Builder(context!!, Const.KINYU_CHANNEL_ID)
-                    .setSmallIcon(R.drawable.ic_launcher_background)
-                    .setContentTitle(contentTitle)
-                    .setContentText(contentText)
-                    .setAutoCancel(true)
-                    .setDefaults(NotificationCompat.DEFAULT_ALL)
-                    .setPriority(NotificationCompat.PRIORITY_HIGH)
-                    .setContentIntent(pendingIntent)
-
-                val notificationManagerCompat = NotificationManagerCompat.from(context!!)
-                notificationManagerCompat.notify(0, builder.build())    // 한번에 묶어서
-//                notificationManagerCompat.notify(index, builder.build())  // 따로따로
+            val contentTitle = Const.FIX_EXPENSE_NOTI_CONTENT_TITLE
+            // 明日(XXXX-XX-XX)
+            var contentText = "${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_1} ($tomorrow)\n"
+            var sum = 0
+            for (item in fixExpenseList) {
+                contentText += "${item.name} ${item.price}円\n"
+                item.price?.let {
+                    sum+= it
+                }
             }
+            contentText += "合計(${sum}円) ${Const.FIX_EXPENSE_NOTI_CONTENT_TEXT_2}"
+
+            val builder = NotificationCompat.Builder(context!!, Const.KINYU_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_launcher_background)
+                .setContentTitle(contentTitle)
+                .setContentText(contentText)
+                .setAutoCancel(true)
+                .setStyle(NotificationCompat.BigTextStyle())
+                .setDefaults(NotificationCompat.DEFAULT_ALL)
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setContentIntent(pendingIntent)
+
+            val notificationManagerCompat = NotificationManagerCompat.from(context!!)
+            notificationManagerCompat.notify(Const.FIX_EXPENSE_NOTIFICATION_ID, builder.build())    // 한번에 묶어서
         }
     }
 }

--- a/app/src/main/java/com/jp_ais_training/keibo/receiver/KinyuNotiReceiver.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/receiver/KinyuNotiReceiver.kt
@@ -72,12 +72,13 @@ class KinyuNotiReceiver: BroadcastReceiver() {
                         .setContentTitle(contentTitle)
                         .setContentText(contentText)
                         .setAutoCancel(true)
+                        .setStyle(NotificationCompat.BigTextStyle())
                         .setDefaults(NotificationCompat.DEFAULT_ALL)
                         .setPriority(NotificationCompat.PRIORITY_HIGH)
                         .setContentIntent(pendingIntent)
 
                     val notificationManagerCompat = NotificationManagerCompat.from(context!!)
-                    notificationManagerCompat.notify(0, builder.build())
+                    notificationManagerCompat.notify(Const.KINYU_NOTIFICATION_ID, builder.build())
                 }
             }
         }

--- a/app/src/main/java/com/jp_ais_training/keibo/util/Const.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/util/Const.kt
@@ -12,7 +12,9 @@ object Const {
     val FIX_EXPENSE_CHANNEL_ID = "FIXEXPENSE"
     val FIX_EXPENSE_CHANNEL_NAME = "FIXEXPENSE CHANNEL"
 
-    val KINYU_NOTIFICATION = -777
+    val KINYU_NOTIFICATION_ID = 0
+    val COMPARISON_NOTIFICATION_ID = 1
+    val FIX_EXPENSE_NOTIFICATION_ID = 2
     val IS_INIT_KINYU_NOTI = "isInitKinyuNoti"
     val IS_INIT_COMPARISON_NOTI = "isInitComparisonNoti"
     val NOTI_KEY = "Noti"
@@ -33,7 +35,7 @@ object Const {
     val COMPARISON_NOTI_CONTENT_TEXT_1 = "前月総支出："
     val COMPARISON_NOTI_CONTENT_TEXT_2 = "今月総支出："
     val COMPARISON_NOTI_CONTENT_TEXT_3 = "前月に比べ "
-    val COMPARISON_NOTI_CONTENT_TEXT_4 = "円ほど使いました。"
+    val COMPARISON_NOTI_CONTENT_TEXT_4 = "円使いました。"
 
 
     val KINYU_MAIN_ACTIVITY_EXTRA_YEAR = "year"

--- a/app/src/main/res/layout/dialog_test.xml
+++ b/app/src/main/res/layout/dialog_test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+   <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:tools="http://schemas.android.com/tools"
+       android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+
+
+        <TextView
+            android:id="@+id/prev"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+
+            tools:text="h2"
+
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/current"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+      <TextView
+           android:id="@+id/current"
+           android:layout_width="200dp"
+           android:layout_height="200dp"
+
+           tools:text="h2"
+
+           app:layout_constraintTop_toBottomOf="@+id/prev"
+           app:layout_constraintBottom_toBottomOf="parent"
+           app:layout_constraintStart_toStartOf="parent"
+           app:layout_constraintEnd_toEndOf="parent"
+           />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -204,6 +204,56 @@
                     app:layout_constraintHorizontal_chainStyle="spread_inside"
                     />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+
+                app:layout_constraintTop_toBottomOf="@+id/cl_comparison_noti"
+                app:layout_constraintBottom_toBottomOf="parent"
+                >
+
+                <Button
+                    android:id="@+id/btn_auto_add"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="毎月固定支出自動追加"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@+id/btn_kinyu_noti"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+                <Button
+                    android:id="@+id/btn_kinyu_noti"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="記入要請"
+                    app:layout_constraintTop_toBottomOf="@+id/btn_auto_add"
+                    app:layout_constraintBottom_toTopOf="@+id/btn_comparison_noti"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+                <Button
+                    android:id="@+id/btn_comparison_noti"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="支出比較"
+                    app:layout_constraintTop_toBottomOf="@+id/btn_kinyu_noti"
+                    app:layout_constraintBottom_toTopOf="@+id/btn_fix_expense_noti"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+                <Button
+                    android:id="@+id/btn_fix_expense_noti"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="固定支出通知"
+                    app:layout_constraintTop_toBottomOf="@+id/btn_comparison_noti"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </FrameLayout>


### PR DESCRIPTION
Closes #67 

- ComparisonExpenseNotiReceiver.kt: 오류 수정 및 notification 스타일 추가(전체 텍스트를 볼 수 있도록)
- Const.kt: 기능별로 알림이 따로 발생하도록 알림id 설정
- FixExpenseReceiver.kt: 여러개의 고정지출 한 알림에 표시될 수 있도록 로직 수정
- fragment_settings.xml: 알림 테스트용 버튼 추가
- KinyuNotiReceiver.kt: 알림 스타일 및 알림id 설정
- SettingsFragment.kt: 알림 테스트 로직 추가
- dialog_test.xml: 매달 1일 고정지출 자동 추가 기능 테스트를 위한 다이얼로그
- 

![test1](https://user-images.githubusercontent.com/56281493/170924791-1791cc52-6204-456c-9d31-afbfdee6dc09.png)
![test2](https://user-images.githubusercontent.com/56281493/170924801-c41c6ebb-1d0a-4785-a730-4815cffd587c.png)
![test3](https://user-images.githubusercontent.com/56281493/170924810-039f3bcb-5cc5-4b9b-a7b8-163f98476254.png)
