### PR TITLE
원그래프 데이터 화면 데이터 처리방법 수정, 기타 기능 수정

### DIFF
--- a/app/src/main/java/com/jp_ais_training/keibo/frament/CircleStatisticsFragment.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/frament/CircleStatisticsFragment.kt
@@ -3,6 +3,7 @@ package com.jp_ais_training.keibo.frament
 import android.R
 import android.graphics.Color
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,8 +14,8 @@ import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
 import com.github.mikephil.charting.data.PieEntry
 import com.github.mikephil.charting.utils.ColorTemplate
+import com.jp_ais_training.keibo.KeiboApplication
 import com.jp_ais_training.keibo.databinding.FragmentCircleStatisticsBinding
-import com.jp_ais_training.keibo.db.AppDatabase
 import kotlinx.coroutines.*
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -34,7 +35,9 @@ class CircleStatisticsFragment : Fragment() {
     //칼랜더 변수 선언
     val cal = Calendar.getInstance()
     //DB 선언
-    private lateinit var DB: AppDatabase
+    private lateinit var app: KeiboApplication
+
+    var mainCategoryName = ""
     var mainSumBundle = ""
 
     // 부모 리스트
@@ -42,15 +45,18 @@ class CircleStatisticsFragment : Fragment() {
     // 자식 리스트
     val childData: ArrayList<ArrayList<HashMap<String, String?>>> = ArrayList()
 
+    //중복 클릭 처리 변수
+    private var mLaskClickTime: Long = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        app = requireActivity().application as KeiboApplication
     }
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         mBinding = FragmentCircleStatisticsBinding.inflate(inflater, container, false)
-        DB = AppDatabase.getInstance(requireContext())!!
 
         //월별 이동 처리 기준
         dateStandard = 0
@@ -61,6 +67,7 @@ class CircleStatisticsFragment : Fragment() {
 
         //원그래프
         pieChart = binding.pieChart
+        clearPieChart()
 
         //최초 기간 표시
         binding.circleKikanTv.setText(
@@ -72,27 +79,17 @@ class CircleStatisticsFragment : Fragment() {
         binding.naviYokugetsuBtn.visibility = View.INVISIBLE
         binding.naviYokugetsuBtn.isEnabled = false
 
-        runBlocking { delay(300L)
-        //해당 월 데이터가 없는경우
-        if(pickOutMainPrice(df.format(cal.time).substring(0,7)) == ""){
-            clearPieChart()
-            binding.pieChart.visibility = View.INVISIBLE
-            binding.noDataTv.visibility = View.VISIBLE
-        }else{
-            //해당 월 메인카테고리별 데이터 취득
-            binding.pieChart.visibility = View.VISIBLE
-            binding.noDataTv.visibility = View.INVISIBLE
-            clearPieChart()
-            setPieChartOption()
-            setPieChartItem(pickOutMainPrice(df.format(cal.time).substring(0,7)))
-            setPieChartDataSet()
-            }
-        }
+        pickOutMainPrice(df.format(cal.time).substring(0,7))
 
         //버튼 클릭 이벤트 -----------------------------------------------------------------------------------------
         //전달 통계 표시 버튼
-        //TODO 전달의 지출 데이터가 없을 경우 Invisible 처리
         binding.naviSengetsuBtn.setOnClickListener(){
+            //중복 클릭 방지 처리 (2.5초)
+            if(SystemClock.elapsedRealtime() - mLaskClickTime<2500){
+                return@setOnClickListener
+            }
+            mLaskClickTime = SystemClock.elapsedRealtime()
+            clearPieChart()
             moveLastMonth()
 
             //전달 기간 표시
@@ -100,25 +97,17 @@ class CircleStatisticsFragment : Fragment() {
             binding.circleKikanTv.setText(
                 df.format(cal.time).substring(0,4) + "年" + df.format(cal.time).substring(5,7) + "月"
             )
-            runBlocking { delay(300L)
-                //해당 월 데이터가 없는경우
-                if(pickOutMainPrice(df.format(cal.time).substring(0,7)) == ""){
-                    clearPieChart()
-                    binding.pieChart.visibility = View.INVISIBLE
-                    binding.noDataTv.visibility = View.VISIBLE
-                }else{
-                    //해당 월 메인카테고리별 데이터 취득
-                    binding.pieChart.visibility = View.VISIBLE
-                    binding.noDataTv.visibility = View.INVISIBLE
-                    clearPieChart()
-                    setPieChartOption()
-                    setPieChartItem(pickOutMainPrice(df.format(cal.time).substring(0,7)))
-                    setPieChartDataSet()
-                }
-            }
+            pickOutMainPrice(df.format(cal.time).substring(0,7))
         }
         //다음달 통계 표시 버튼 -> dateStandard = 0이 될 경우 Invisible 처리
         binding.naviYokugetsuBtn.setOnClickListener(){
+            //중복 클릭 방지 처리 (2.5초)
+            if(SystemClock.elapsedRealtime() - mLaskClickTime<2500){
+                return@setOnClickListener
+            }
+            mLaskClickTime = SystemClock.elapsedRealtime()
+            var mainCategoryName = ""
+            clearPieChart()
             moveNextMonth()
 
             //다음달 기간 표시
@@ -128,42 +117,13 @@ class CircleStatisticsFragment : Fragment() {
                     df.format(cal.time).substring(0,4) + "年" + df.format(cal.time).substring(5,7)+"月01日 ~ "
                             + df.format(cal.time).substring(8,10) +"日"
                 )
-                runBlocking { delay(300L)
-                    //해당 월 데이터가 없는경우
-                    if(pickOutMainPrice(df.format(cal.time).substring(0,7)) == ""){
-                        clearPieChart()
-                        binding.pieChart.visibility = View.INVISIBLE
-                        binding.noDataTv.visibility = View.VISIBLE
-                    }else{
-                        //해당 월 메인카테고리별 데이터 취득
-                        binding.pieChart.visibility = View.VISIBLE
-                        binding.noDataTv.visibility = View.INVISIBLE
-                        clearPieChart()
-                        setPieChartOption()
-                        setPieChartItem(pickOutMainPrice(df.format(cal.time).substring(0,7)))
-                        setPieChartDataSet()
-                    }
-                }
+                pickOutMainPrice(df.format(cal.time).substring(0,7))
+
             }else{
                 binding.circleKikanTv.setText(
                     df.format(cal.time).substring(0,4) + "年" + df.format(cal.time).substring(5,7) + "月"
                 )
-                runBlocking { delay(300L)
-                    //해당 월 데이터가 없는경우
-                    if(pickOutMainPrice(df.format(cal.time).substring(0,7)) == ""){
-                        clearPieChart()
-                        binding.pieChart.visibility = View.INVISIBLE
-                        binding.noDataTv.visibility = View.VISIBLE
-                    }else{
-                        //해당 월 메인카테고리별 데이터 취득
-                        binding.pieChart.visibility = View.VISIBLE
-                        binding.noDataTv.visibility = View.INVISIBLE
-                        clearPieChart()
-                        setPieChartOption()
-                        setPieChartItem(pickOutMainPrice(df.format(cal.time).substring(0,7)))
-                        setPieChartDataSet()
-                    }
-                }
+                pickOutMainPrice(df.format(cal.time).substring(0,7))
             }
         }
 
@@ -181,6 +141,7 @@ class CircleStatisticsFragment : Fragment() {
         pieChart!!.description!!.isEnabled = false
         pieChart!!.setExtraOffsets(5f, 10f, 5f, 5f)
         pieChart!!.dragDecelerationFrictionCoef = 0.95f
+        pieChart!!.setEntryLabelTextSize(0f)
         pieChart!!.isDrawHoleEnabled = false
         pieChart!!.setHoleColor(Color.WHITE)
         pieChart!!.transparentCircleRadius = 61f
@@ -189,12 +150,15 @@ class CircleStatisticsFragment : Fragment() {
     }
 
     //원그래프 항목 추가
-    private fun setPieChartItem(setPieItem: String) {
+    suspend fun setPieChartItem(setPieItem: String) {
         val arr = setPieItem.split(",")
-        for (i in arr){
-            yValues.add(PieEntry(i.toFloat(), ""))
-            println("$i")
+        val arr2 = mainCategoryName.split(",")
+        if(arr.isNotEmpty()){
+            for (i in 0 until arr.size-1){
+                yValues.add(PieEntry(arr[i].toFloat(), arr2[i]))
+            }
         }
+        delay(300L)
     }
 
     //원그래프 데이터 세팅
@@ -205,7 +169,8 @@ class CircleStatisticsFragment : Fragment() {
         dataSet.setColors(*ColorTemplate.JOYFUL_COLORS)
 
         val data = PieData(dataSet)
-        data.setValueTextSize(0f)
+        data.setValueTextSize(10f);
+        data.setValueTextColor(Color.WHITE);
 
         pieChart?.data = data
     }
@@ -221,12 +186,10 @@ class CircleStatisticsFragment : Fragment() {
     private fun moveLastMonth() {
         //초기화면 기준 0 전달 이동시 -1 다음달 이동 시 +1
         dateStandard += -1
-        System.out.println(dateStandard)
 
         if(dateStandard < 0){
             binding.naviYokugetsuBtn.visibility = View.VISIBLE
             binding.naviYokugetsuBtn.isEnabled = true
-            System.out.println(dateStandard)
         }
     }
 
@@ -234,30 +197,44 @@ class CircleStatisticsFragment : Fragment() {
     private fun moveNextMonth() {
         if(dateStandard == -1){
             dateStandard += 1
-            System.out.println(dateStandard)
             binding.naviYokugetsuBtn.visibility = View.INVISIBLE
             binding.naviYokugetsuBtn.isEnabled = false
         }else{
             dateStandard += 1
-            System.out.println(dateStandard)
         }
     }
-    //메인 카테고리 기준 DB 결과 값 가격 추출  <--  "yyyy-mm"형식 날짜, 메인 카테고리 번호 입력
-    private fun pickOutMainPrice(setDate: String):String{
-        DB = AppDatabase.getInstance(requireContext())!!
 
+    //메인 카테고리 기준 DB 결과 값 가격 추출  <--  "yyyy-mm"형식 날짜, 메인 카테고리 번호 입력
+    private fun pickOutMainPrice(setDate: String){
         //DB에서 데이터 가져오기
-        CoroutineScope(Dispatchers.Main).launch {
+        CoroutineScope(Dispatchers.Main).launch{
+            //원그래프 옵션 설정
+            setPieChartOption()
             withContext(CoroutineScope(Dispatchers.IO).coroutineContext) {
-                var sumTest1 = DB.dao().loadMonthSumMainCategoryEI(setDate)
+                var sumTest1 = app.db.loadMonthSumMainCategoryEI(setDate)
+                //println(app.db.loadMonthSumSubCategoryEI(setDate))
 
                 //초기 string 변수 선언
                 var str_data = sumTest1.toString()
-                println("초기 문자열 : $str_data")
-
                 //공백 제거
                 str_data = str_data.replace(" ", "")
-                println("공백 제거 : $str_data")
+
+                val nameSet1 = arrayOf(
+                    "公課金,main_id=1,type=fix","生活,main_id=2,type=fix","その他,main_id=3,type=fix",
+                    "食費,main_id=4,type=flex","生活,main_id=5,type=flex","余暇,main_id=6,type=flex",
+                    "文化,main_id=7,type=flex","自己開発,main_id=8,type=flex","その他,main_id=9,type=flex"
+                )
+                val nameSet2 = arrayOf(
+                    "公課金,","生活,","その他,",
+                    "食費,","生活,","余暇,",
+                    "文化,","自己開発,","その他,"
+                )
+                //메인 카테고리명 취득
+                for(i in 0..8){
+                    if(str_data.contains(nameSet1[i])){
+                        mainCategoryName = mainCategoryName.plus(nameSet2[i])
+                    }
+                }
 
                 //특정 문자열 변경
                 str_data = str_data.replace("LoadSumMainCategoryEI(date=", "")
@@ -273,14 +250,13 @@ class CircleStatisticsFragment : Fragment() {
                 str_data = str_data.replace(",main_name=その他,main_id=9,type=flex)", "")
                 str_data = str_data.replace("[", "")
                 str_data = str_data.replace("]", "")
-                //str_data = str_data.replace(",", "")
-                println("문자 변경 : $str_data")
                 mainSumBundle = str_data
-                println("mainSumBundle1 : $mainSumBundle")
+
+                //원그래프 항목, 데이터 설정
+                setPieChartItem(mainSumBundle)
+                setPieChartDataSet()
             }
         }
-        println("mainSumBundle2 : $mainSumBundle")
-        return mainSumBundle
     }
 
     //확장리스트 -----------------------------------------------------------------------------------
@@ -357,6 +333,9 @@ class CircleStatisticsFragment : Fragment() {
         val listView = binding.circleExV
         listView.setAdapter(adapter)
     }
+
+    //--------------------------------------------------------------------------------------------
+
     override fun onDestroyView() {
         //원그래프 데이터 초기화
         clearPieChart()
@@ -367,7 +346,6 @@ class CircleStatisticsFragment : Fragment() {
 
         //월별 이동 처리 기준 초기화
         dateStandard = 0
-        System.out.println(dateStandard)
 
         mBinding = null
 

--- a/app/src/main/res/layout/fragment_circle_statistics.xml
+++ b/app/src/main/res/layout/fragment_circle_statistics.xml
@@ -74,7 +74,7 @@
             android:gravity="right"
             android:textColor="@color/black"/>
 
-        <LinearLayout
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="200dp"
             android:orientation="vertical">
@@ -84,18 +84,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
 
-            <TextView
-                android:id="@+id/noDataTv"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:layout_gravity="center_vertical"
-                android:gravity="center"
-                android:visibility="invisible"
-                android:text="データがございません。"
-                android:textColor="@color/black"
-                android:textSize="30dp"
-                />
-        </LinearLayout>
+        </FrameLayout>
 
         <LinearLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
-원그래프 데이터 처리 (원그래프 세팅함수 코루틴 안으로 이동)
-메인 카테고리 항목명 표시
-월 이동 버튼 중복클릭방지 처리 -> 2.5초딜레이
-확장리스트 기본 레이아웃(임의 데이터)