### PR TITLE
[라이센스 페이지] Feature/81 license

### DIFF
--- a/app/src/main/java/com/jp_ais_training/keibo/frament/SettingsFragment.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/frament/SettingsFragment.kt
@@ -1,12 +1,16 @@
 package com.jp_ais_training.keibo.frament
 
+import android.app.AlertDialog
 import android.app.Dialog
 import android.app.PendingIntent
-import android.content.Context.MODE_PRIVATE
+import android.content.DialogInterface
 import android.content.Intent
-import android.content.SharedPreferences
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import android.text.style.UnderlineSpan
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -26,6 +30,7 @@ import com.jp_ais_training.keibo.util.Const
 import com.jp_ais_training.keibo.util.NotificationUtil
 import com.jp_ais_training.keibo.util.PreferenceUtil
 import kotlinx.coroutines.*
+import java.io.InputStream
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -45,6 +50,7 @@ class SettingsFragment : Fragment() {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_settings, container, false)
 
         initSwitchValue()
+        initLicenseTextView()
         setClickEvent()
 
         setTestEvent()
@@ -69,6 +75,13 @@ class SettingsFragment : Fragment() {
         binding.swiFixExpenseNoti.isChecked= isRunningFixExpenseNoti
         binding.swiKinyuNoti.isChecked= isRunningKinyuNoti
         binding.swiComparisonNoti.isChecked= isRunningComparisonExpenseNoti
+    }
+
+    private fun initLicenseTextView() {
+        val content = SpannableString(Const.LICENSE_TEXTVIEW_TEXT)
+        content.setSpan(UnderlineSpan(), 0, content.length, 0)
+        content.setSpan(ForegroundColorSpan(Color.BLUE), 0, content.length, 0)
+        binding.tvLicense.text = content
     }
 
     // 화면 클릭 이벤트 설정
@@ -116,6 +129,27 @@ class SettingsFragment : Fragment() {
 
             updateNotification(Const.PREF_COMPARISON_EXPENSE_NOTI_KEY)
         }
+
+        // Licenseについて 클릭
+        binding.tvLicense.setOnClickListener {
+            val builder = AlertDialog.Builder(requireContext())
+
+            val inputStream: InputStream = this.resources.openRawResource(R.raw.license)
+            val buffer = ByteArray(inputStream.available())
+            while (inputStream.read(buffer) !== -1){ }
+            val licenseText = String(buffer)
+            builder.setMessage(licenseText)
+            builder.setNegativeButton("閉じる", object: DialogInterface.OnClickListener {
+                override fun onClick(view: DialogInterface?, which: Int) {
+                    view?.dismiss()
+                }
+            })
+            val dialog = builder.create()
+            dialog.show()
+
+
+        }
+
     }
 
     // 스위치의 현재 상태를 확인해
@@ -262,7 +296,7 @@ class SettingsFragment : Fragment() {
         val contentTitle = Const.KINYU_NOTI_CONTENT_TITLE
         val contentText = "$today\n${Const.KINYU_NOTI_CONTENT_TEXT}"
 
-        val builder = NotificationCompat.Builder(requireContext()!!, Const.KINYU_CHANNEL_ID)
+        val builder = NotificationCompat.Builder(requireContext(), Const.KINYU_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_background)
             .setContentTitle(contentTitle)
             .setContentText(contentText)
@@ -389,7 +423,7 @@ class SettingsFragment : Fragment() {
 
     private fun convertStringToCalendar(itemDatetime: String?): Calendar {
         val sdf = SimpleDateFormat("yyyy-MM-dd")
-        val date: Date = sdf.parse(itemDatetime)
+        val date = sdf.parse(itemDatetime)
         val cal = Calendar.getInstance()
         cal.time = date
 

--- a/app/src/main/java/com/jp_ais_training/keibo/util/Const.kt
+++ b/app/src/main/java/com/jp_ais_training/keibo/util/Const.kt
@@ -67,4 +67,6 @@ object Const {
     val PREF_FIX_EXPENSE_NOTI_KEY = "FixExpenseNoti"
     val PREF_KINYU_NOTI_KEY = "KinyuNoti"
     val PREF_COMPARISON_EXPENSE_NOTI_KEY = "ComparisonExpense"
+
+    val LICENSE_TEXTVIEW_TEXT = "Licenseについて"
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -265,7 +265,22 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     />
             </androidx.constraintlayout.widget.ConstraintLayout>
-        </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <TextView
+                android:id="@+id/tv_license"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="Licenseについて"
+
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+
+                app:layout_constraintVertical_bias="1"
+                android:layout_marginBottom="15dp"
+                />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </FrameLayout>
 </layout>

--- a/app/src/main/res/raw/license.txt
+++ b/app/src/main/res/raw/license.txt
@@ -1,6 +1,20 @@
-
-ExpandableLayout
+- ExpandableLayout
 Copyright 2016 Daniel Cachapa.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+- Retrofit
+Copyright 2013 Square, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/app/src/main/res/raw/license.txt
+++ b/app/src/main/res/raw/license.txt
@@ -30,7 +30,7 @@ limitations under the License.
 
 
 
-
+- MPChart(PieChart, BarChart)
 Copyright 2020 Philipp Jahoda
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.

--- a/app/src/main/res/raw/license.txt
+++ b/app/src/main/res/raw/license.txt
@@ -1,0 +1,15 @@
+
+ExpandableLayout
+Copyright 2016 Daniel Cachapa.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/app/src/main/res/raw/license.txt
+++ b/app/src/main/res/raw/license.txt
@@ -27,3 +27,17 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+
+
+
+Copyright 2020 Philipp Jahoda
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.


### PR DESCRIPTION
# What To Do
- Const.kt : 라이센스 텍스트뷰 텍스트 선언
- fragment_settings.xml : 라이센스 텍스트뷰 추가
- SettingsFragment.kt : SpannableString을 활용해서 텍스트뷰 스타일 적용, 클릭시 다이얼로그 출력 로직
- app/src/main/res/raw/license.txt : 라이센스 텍스트 파일

# Result
![license1](https://user-images.githubusercontent.com/56281493/171133802-c6c4a212-f4a2-41af-939d-accd3fc76d5a.png)
![license2](https://user-images.githubusercontent.com/56281493/171133813-15283493-387e-404e-8668-3ea53a109bb6.png)
